### PR TITLE
Feat/add windows 64 detection

### DIFF
--- a/lib/platform.rb
+++ b/lib/platform.rb
@@ -67,15 +67,15 @@ module Platform
 
    # What about AMD, Turion, Motorola, etc..?
    ARCHS = [
-      [ /i\d86/,     :x86 ],
-      [ /x86_64/,    :x86_64],
-      [ /ia64/,      :ia64 ],
-      [ /powerpc/,   :powerpc ],
-      [ /alpha/,     :alpha ],
-      [ /sparc/i,    :sparc ],
-      [ /mips/i,     :mips ],
-      [ /hppa/i,     :parisc ],
-      [ /.*/,        :unknown ]
+      [ /i\d86/,        :x86 ],
+      [ /x86_64|x64/,   :x86_64],
+      [ /ia64/,         :ia64 ],
+      [ /powerpc/,      :powerpc ],
+      [ /alpha/,        :alpha ],
+      [ /sparc/i,       :sparc ],
+      [ /mips/i,        :mips ],
+      [ /hppa/i,        :parisc ],
+      [ /.*/,           :unknown ]
    ]
    (*), ARCH = ARCHS.find { |a| RUBY_PLATFORM =~ /#{a[0]}/}
    

--- a/platform.gemspec
+++ b/platform.gemspec
@@ -2,10 +2,10 @@ require 'rubygems'
 
 SPEC = Gem::Specification.new do |s| 
    s.name = "Platform" 
-   s.version = "0.4.1" 
-   s.author = "Matt Mower" 
-   s.email = "self@mattmower.com" 
-   s.homepage = "http://rubyforge.org/projects/platform/" 
+   s.version = "0.4.2" 
+   s.author = "Matt Mower, Kraig Strong" 
+   s.email = "self@mattmower.com, kraig.strong@gmail.com" 
+   s.homepage = "https://github.com/kraigstrong/platform" 
    s.platform = Gem::Platform::RUBY 
    s.summary = "Hopefully robust platform sensing" 
    candidates = Dir.glob("{bin,docs,lib,tests}/**/*") 

--- a/platform.gemspec
+++ b/platform.gemspec
@@ -3,8 +3,8 @@ require 'rubygems'
 SPEC = Gem::Specification.new do |s| 
    s.name = "Platform" 
    s.version = "0.4.2" 
-   s.author = "Matt Mower, Kraig Strong" 
-   s.email = "self@mattmower.com, kraig.strong@gmail.com" 
+   s.authors = ["Matt Mower", "Kraig Strong"] 
+   s.emails = ["self@mattmower.com", "kraig.strong@gmail.com"]
    s.homepage = "https://github.com/kraigstrong/platform" 
    s.platform = Gem::Platform::RUBY 
    s.summary = "Hopefully robust platform sensing" 


### PR DESCRIPTION
##Purpose
Unable to detect 64 bit windows ruby versions as it reports x64_mingw32. This adds that capability

##Testing
Ran locally on my x64 and x32 windows sytems. Both report x86_64